### PR TITLE
[FIX]: Invalid memory access in sortedlist

### DIFF
--- a/src/gen/generator/generatorVariable.cpp
+++ b/src/gen/generator/generatorVariable.cpp
@@ -182,33 +182,35 @@ std::vector<std::string> GeneratorSortedList::insert() {
     std::string tmp_varname = "tmp" + std::to_string(VariableFactory::var_counter);
     std::string int_tmp_varname = "tmp_val" + std::to_string(VariableFactory::var_counter);
 
-    tmp.push_back("cell_t* " + cell_varname + " = " + this->name + "->root;");
-    tmp.push_back("if(" + this->name + "->n == 0) {");
-    tmp.push_back("    " + this->name + "->root = (cell_t*)malloc(sizeof(cell_t));");
-    tmp.push_back("    " + this->name + "->root->val  = " + std::to_string(value) + ";");
-    tmp.push_back("    " + this->name + "->root->next = NULL;");
-    tmp.push_back("    " + this->name + "->n++;");
-    tmp.push_back("} else {");
-    tmp.push_back("    while(" + cell_varname + " != NULL)");
-    tmp.push_back("    {");
-    tmp.push_back("        if(" + cell_varname + "->next == NULL && " + cell_varname + "->val < " + std::to_string(value) + ") {");
-    tmp.push_back("            " + cell_varname + "->next = (cell_t*)malloc(sizeof(cell_t));");
-    tmp.push_back("            " + cell_varname + "->next->next = NULL;");
-    tmp.push_back("            " + cell_varname + "->next->val  = " + std::to_string(value) + ";");
-    tmp.push_back("            " + this->name + "->n++;");
-    tmp.push_back("            return " + this->name + ";");
-    tmp.push_back("        } else if(" + std::to_string(value) + " < " + cell_varname + "->val) {");
-    tmp.push_back("            cell_t* " + tmp_varname + " = " + cell_varname + "->next;");
-    tmp.push_back("            " + cell_varname + "->next = (cell_t*)malloc(sizeof(cell_t));");
-    tmp.push_back("            " + cell_varname + "->next->next = " + tmp_varname + ";");
-    tmp.push_back("            int " + int_tmp_varname + " = " + cell_varname + "->val;");
-    tmp.push_back("            " + cell_varname + "->val = " + std::to_string(value) + ";");
-    tmp.push_back("            " + cell_varname + "->next->val = " + int_tmp_varname + ";");
-    tmp.push_back("            " + this->name + "->n++;");
-    tmp.push_back("            return " + this->name + ";");
-    tmp.push_back("        }");
-    tmp.push_back("        " + cell_varname + " = " + cell_varname + "->next;");
-    tmp.push_back("    }");
+    tmp.push_back("if("+this->name+" != NULL && "+this->name+"->n > 0) {");
+    tmp.push_back("     cell_t* " + cell_varname + " = " + this->name + "->root;");
+    tmp.push_back("     if(" + this->name + "->n == 0) {");
+    tmp.push_back("         " + this->name + "->root = (cell_t*)malloc(sizeof(cell_t));");
+    tmp.push_back("         " + this->name + "->root->val  = " + std::to_string(value) + ";");
+    tmp.push_back("         " + this->name + "->root->next = NULL;");
+    tmp.push_back("         " + this->name + "->n++;");
+    tmp.push_back("     } else {");
+    tmp.push_back("         while(" + cell_varname + " != NULL)");
+    tmp.push_back("         {");
+    tmp.push_back("             if(" + cell_varname + "->next == NULL && " + cell_varname + "->val < " + std::to_string(value) + ") {");
+    tmp.push_back("                 " + cell_varname + "->next = (cell_t*)malloc(sizeof(cell_t));");
+    tmp.push_back("                 " + cell_varname + "->next->next = NULL;");
+    tmp.push_back("                 " + cell_varname + "->next->val  = " + std::to_string(value) + ";");
+    tmp.push_back("                 " + this->name + "->n++;");
+    tmp.push_back("                 return " + this->name + ";");
+    tmp.push_back("             } else if(" + std::to_string(value) + " < " + cell_varname + "->val) {");
+    tmp.push_back("                 cell_t* " + tmp_varname + " = " + cell_varname + "->next;");
+    tmp.push_back("                 " + cell_varname + "->next = (cell_t*)malloc(sizeof(cell_t));");
+    tmp.push_back("                 " + cell_varname + "->next->next = " + tmp_varname + ";");
+    tmp.push_back("                 int " + int_tmp_varname + " = " + cell_varname + "->val;");
+    tmp.push_back("                 " + cell_varname + "->val = " + std::to_string(value) + ";");
+    tmp.push_back("                 " + cell_varname + "->next->val = " + int_tmp_varname + ";");
+    tmp.push_back("                 " + this->name + "->n++;");
+    tmp.push_back("                 return " + this->name + ";");
+    tmp.push_back("             }");
+    tmp.push_back("             " + cell_varname + " = " + cell_varname + "->next;");
+    tmp.push_back("         }");
+    tmp.push_back("     }");
     tmp.push_back("}");
     VariableFactory::var_counter++;
     return tmp;
@@ -221,7 +223,7 @@ std::vector<std::string> GeneratorSortedList::remove() {
 
     std::string cell_varname = "cell" + std::to_string(VariableFactory::var_counter);
 
-    tmp.push_back("if(" + this->name + "->n > 0)");
+    tmp.push_back("if("+this->name+" != NULL && "+this->name+"->n > 0)");
     tmp.push_back("{");
     tmp.push_back("    cell_t* " + cell_varname + " = " + this->name + "->root;");
     tmp.push_back("    if(" + cell_varname + "->val == " + std::to_string(value) + ")");
@@ -252,10 +254,11 @@ std::vector<std::string> GeneratorSortedList::contains(bool shouldReturn) {
     int value = rand() % 100;
 
     std::string cell_varname = "cell" + std::to_string(VariableFactory::var_counter);
-
-    tmp.push_back("cell_t* " + cell_varname + " = " + this->name + "->root;");
-    tmp.push_back("while(" + cell_varname + " != NULL && " + cell_varname + "->val != " + std::to_string(value) + ") " + cell_varname + " = " + cell_varname + "->next;");
-    tmp.push_back("return " + cell_varname + " != NULL ? " + this->name + " : NULL;");
+    tmp.push_back("if("+this->name+" != NULL && "+this->name+"->n > 0){");
+    tmp.push_back("     cell_t* " + cell_varname + " = " + this->name + "->root;");
+    tmp.push_back("     while(" + cell_varname + " != NULL && " + cell_varname + "->val != " + std::to_string(value) + ") " + cell_varname + " = " + cell_varname + "->next;");
+    tmp.push_back("     return " + cell_varname + " != NULL ? " + this->name + " : NULL;");
+    tmp.push_back("}");
     VariableFactory::var_counter++;
 
     return tmp;
@@ -266,15 +269,16 @@ std::vector<std::string> GeneratorSortedList::free() {
 
     std::string cell_varname = "cell" + std::to_string(VariableFactory::var_counter);
     std::string tmp_varname = "tmp" + std::to_string(VariableFactory::var_counter);
-
-    tmp.push_back("cell_t* " + cell_varname + " = " + this->name + "->root;");
-    tmp.push_back("cell_t* " + tmp_varname + "  = NULL;");
-    tmp.push_back("while(" + cell_varname + " != NULL) {");
-    tmp.push_back("     " + tmp_varname + " = " + cell_varname + "->next;");
-    tmp.push_back("     free(" + cell_varname + ");");
-    tmp.push_back("     " + cell_varname + " = " + tmp_varname + ";");
+    tmp.push_back("if("+this->name+" != NULL && "+this->name+"->n > 0){");
+    tmp.push_back("     cell_t* " + cell_varname + " = " + this->name + "->root;");
+    tmp.push_back("     cell_t* " + tmp_varname + "  = NULL;");
+    tmp.push_back("     while(" + cell_varname + " != NULL) {");
+    tmp.push_back("          " + tmp_varname + " = " + cell_varname + "->next;");
+    tmp.push_back("          free(" + cell_varname + ");");
+    tmp.push_back("          " + cell_varname + " = " + tmp_varname + ";");
+    tmp.push_back("     }");
+    tmp.push_back("     free(" + this->name + ");");
     tmp.push_back("}");
-    tmp.push_back("free(" + this->name + ");");
     VariableFactory::var_counter++;
     return tmp;
 }


### PR DESCRIPTION
This PR fixes the problem of invalid memory access in `sortedlist` `insert()`, `remove()`, `contains()` and `free()` functions.