### PR TITLE
Correction of function execution preference between g++ and clang++ c…

### DIFF
--- a/src/gen/parser/parser.cpp
+++ b/src/gen/parser/parser.cpp
@@ -13,6 +13,7 @@ std::shared_ptr<Node> Parser::parse_CODE() {
     if ((int)tokens.size() <= tokenIndex) {
         return std::make_shared<LambdaCode>(LambdaCode());
     }
+
     switch (tokens[tokenIndex].type) {
         case TOK_INSERT:
         case TOK_REMOVE:
@@ -23,7 +24,10 @@ std::shared_ptr<Node> Parser::parse_CODE() {
         case TOK_SEQ:
         case TOK_IF:
         case TOK_ID:
-            return std::make_shared<StatementCode>(StatementCode(parse_STATEMENT(), parse_CODE()));
+        {
+            std::shared_ptr<Node> n = parse_STATEMENT();
+            return std::make_shared<StatementCode>(StatementCode(n, parse_CODE()));
+        }
         case TOK_CPAREN:
         case TOK_COMMA:
             return std::make_shared<LambdaCode>(LambdaCode());


### PR DESCRIPTION
This PR fixes issue #20.

The error occurred because the g++ compiler prioritized the execution of the recursive call to the function `parse_CODE()` in the following line of code:

```C++
return std::make_shared<StatementCode>(StatementCode(parse_STATEMENT(), parse_CODE()));
```

Thus, the function parse_STATEMENT() was never called.

The execution of the recursion continued until there was no more space on the stack, causing a segmentation fault.

On the other hand, the clang++ compiler prioritizes the execution of the function `parse_STATEMENT()` before the recursive call to `parse_CODE()`.