### PR TITLE
Fixes for Go code generation

### DIFF
--- a/src/gen/generator/go/goGenerator.cpp
+++ b/src/gen/generator/go/goGenerator.cpp
@@ -26,8 +26,7 @@ void GoGenerator::generateRandomNumberGenerator() {
         "            return val",
         "        }",
         "    }",
-        "    n := uint64(rand.Uint32())",
-        "    return (n << 32) | uint64(rand.Uint32())",
+        "    return rng.Uint64()",
         "}",
     });
     functions.push_back(rngFunction);
@@ -39,14 +38,15 @@ void GoGenerator::generateMainFunction() {
     "package main",
     "",
     "import (",
-    "    \"math/rand\"",
+    "    \"math/rand/v2\"",
     "    \"os\"",
     "    \"strconv\"",
     ")",
     "",
+    "var rng = rand.NewPCG(0, 0)"
+    "",
     "func main() {",
     "    loopsFactor := 100",
-    "    rand.Seed(0)",
     "",
     "    args := os.Args",
     "    for i := 1; i < len(args); i++ {",
@@ -55,7 +55,7 @@ void GoGenerator::generateMainFunction() {
     "            if i < len(args) {",
     "                seed, err := strconv.Atoi(args[i])",
     "                if err == nil {",
-    "                    rand.Seed(int64(seed))",
+    "                    rng.Seed(uint64(seed), uint64(seed))",
     "                }",
     "            }",
     "        } else if args[i] == \"-loops-factor\" {",
@@ -327,16 +327,10 @@ void GoGenerator::generateFiles(std::string benchmarkName) {
 
         funcFile << "package main" << std::endl;
 
-        funcFile << "import \"math/rand\"" << std::endl;
-
         if(funcSource == "path.go"){
             funcFile << "import \"os\"" << std::endl;
             funcFile << "import \"strconv\"" << std::endl;
         }
-
-        funcFile <<  "var _ = rand.Intn" << std::endl;
-
-
 
         lines = func.getLines();
         for (auto line : lines) {

--- a/src/gen/generator/go/goGenerator.cpp
+++ b/src/gen/generator/go/goGenerator.cpp
@@ -18,13 +18,20 @@ void GoGenerator::generateGlobalVars() {
 void GoGenerator::generateRandomNumberGenerator() {
     GeneratorFunction rngFunction = GeneratorFunction(-1);
     rngFunction.addLine({
-        "func getPath() uint64 {",
+        "var benchPath, useBenchPath = func() (uint64, bool) {",
         "    path := os.Getenv(\"BENCH_PATH\")",
         "    if path != \"\" {",
         "        val, err := strconv.ParseUint(path, 10, 64)",
         "        if err == nil {",
-        "            return val",
+        "            return val, true",
         "        }",
+        "    }",
+        "    return 0, false",
+        "}()",
+        "",
+        "func getPath() uint64 {",
+        "    if useBenchPath {",
+        "        return benchPath",
         "    }",
         "    return rng.Uint64()",
         "}",

--- a/src/gen/generator/go/goGenerator.cpp
+++ b/src/gen/generator/go/goGenerator.cpp
@@ -1,7 +1,7 @@
 #include "goGenerator.h"
 
 void GoGenerator::generateIncludes() {
-   
+
     std::vector<std::string> varIncludes = VariableFactory::genIncludes(varType);
     for (auto var : varIncludes) {
         globalVars.push_back(var);
@@ -95,7 +95,7 @@ void GoGenerator::startScope() {
 void GoGenerator::startFunc(int funcId, int nParameters) {
     GeneratorFunction func = GeneratorFunction(funcId);
     std::string funcHeader = "func Func" + std::to_string(funcId) + "(vars *" +VariableFactory::genTypeString(varType) + "Param, ";
-    
+
     for (int i = 0; i < nParameters; i++) {
         funcHeader += "PATH" + std::to_string(i) + " uint64 , ";
     }
@@ -107,7 +107,7 @@ void GoGenerator::startFunc(int funcId, int nParameters) {
     GeneratorScope scope = GeneratorScope();
     currentScope.push(scope);
     this->ifCounter.push(0);
-    addLine("var pCounter int = vars.Size;");
+    addLine("var pCounter int = len(vars.Data);");
     addLine("_ = pCounter");
 }
 
@@ -148,9 +148,7 @@ void GoGenerator::callFunc(int funcId, int nParameters) {
     //line = "DEBUG_RETURN(" + var->name + "->id);";
 
     line = param + ".Data = nil";
-    addLine(line);
-    line = param + ".Size = 0";
-    addLine(line);
+    addLine(line);;
 }
 
 int GoGenerator::addVar(std::string type) {
@@ -328,7 +326,7 @@ void GoGenerator::generateFiles(std::string benchmarkName) {
         funcFile.open(sourceDir + funcSource);
 
         funcFile << "package main" << std::endl;
-        
+
         funcFile << "import \"math/rand\"" << std::endl;
 
         if(funcSource == "path.go"){
@@ -337,7 +335,7 @@ void GoGenerator::generateFiles(std::string benchmarkName) {
         }
 
         funcFile <<  "var _ = rand.Intn" << std::endl;
-        
+
 
 
         lines = func.getLines();

--- a/src/gen/generator/go/goGeneratorVariable.cpp
+++ b/src/gen/generator/go/goGeneratorVariable.cpp
@@ -18,7 +18,6 @@ std::vector<std::string> GoGeneratorArray::new_(bool inFunction) {
    //  temp.push_back("    DebugCopy(" + this->name + ".Id)");
      temp.push_back("} else {");
      temp.push_back("    " + this->name + " = &" + this->typeString + "{");
-     temp.push_back("        Size: " + std::to_string(this->totalSize) + ",");
      temp.push_back("        RefC: 1,");
      temp.push_back("        Id: " + std::to_string(this->id) + ",");
      temp.push_back("        Data: make([]uint32, " + std::to_string(this->totalSize) + "),");
@@ -27,7 +26,6 @@ std::vector<std::string> GoGeneratorArray::new_(bool inFunction) {
      temp.push_back("}");
     } else {
         temp.push_back(this->name + " = &" + this->typeString + "{");
-        temp.push_back("    Size: " + std::to_string(this->totalSize) + ",");
         temp.push_back("    RefC: 1,");
         temp.push_back("    Id: " + std::to_string(this->id) + ",");
         temp.push_back("    Data: make([]uint32, " + std::to_string(this->totalSize) + "),");
@@ -39,7 +37,7 @@ return temp;
 
 std::vector<std::string> GoGeneratorArray::insert() {
     std::vector<std::string> temp = {
-    "for i := 0; i < " + this->name + ".Size; i++ {"
+    "for i := range " + this->name + ".Data {"
     };
     temp.push_back("    " + this->name + ".Data[i]++");
     temp.push_back("}");
@@ -48,7 +46,7 @@ std::vector<std::string> GoGeneratorArray::insert() {
 
 std::vector<std::string> GoGeneratorArray::remove() {
     std::vector<std::string> temp = {
-    "for i := 0; i < " + this->name + ".Size; i++ {"
+    "for i := range " + this->name + ".Data {"
     };
     temp.push_back("    " + this->name + ".Data[i]--");
     temp.push_back("}");
@@ -58,7 +56,7 @@ std::vector<std::string> GoGeneratorArray::remove() {
 std::vector<std::string> GoGeneratorArray::contains(bool shouldReturn) {
     int compare = rand() % 100;  // Random value to compare against
     std::vector<std::string> temp = {};
-    temp.push_back("for i := 0; i < " + this->name + ".Size; i++ {");
+    temp.push_back("for i := range " + this->name + ".Data {");
     temp.push_back("    if " + this->name + ".Data[i] == " + std::to_string(compare) + " {");
     if (shouldReturn) {
         temp.push_back("        return " + this->name);
@@ -89,13 +87,11 @@ std::vector<std::string> GoGeneratorArray::genGlobalVars() {
     std::vector<std::string> temp = {};
     temp.push_back("type Array struct {");
     temp.push_back("    Data []uint32");
-    temp.push_back("    Size int");
     temp.push_back("    RefC int");
     temp.push_back("    Id   int");
     temp.push_back("}");
     temp.push_back("type ArrayParam struct {");
     temp.push_back("    Data []*Array");
-    temp.push_back("    Size int");
     temp.push_back("}");
     return temp;
 }
@@ -103,8 +99,7 @@ std::vector<std::string> GoGeneratorArray::genGlobalVars() {
 std::vector<std::string> GoGeneratorArray::genParams(std::string paramName, std::vector<GeneratorVariable*> varsParams) {
     std::vector<std::string> temp = {};
     temp.push_back("var " + paramName + " " + this->typeString + "Param");
-    temp.push_back(paramName + ".Size = " + std::to_string(varsParams.size()));
-    temp.push_back(paramName + ".Data = make([]*" + this->typeString + ", " + paramName + ".Size)");
+    temp.push_back(paramName + ".Data = make([]*" + this->typeString + ", " + std::to_string(varsParams.size()) + ")");
     for (int i = 0; i < (int)varsParams.size(); i++) {
         temp.push_back(paramName + ".Data[" + std::to_string(i) + "] = " + varsParams[i]->name);
     }


### PR DESCRIPTION
I noticed quite a few problems from benchmarking perspective, some of these are present in other languages as well, but I don't have the setup for fixing all of them.

1. The first fix is about Go double tracking size of slices. Slices already know information about their length and tied to their data array. Using that length avoids bounds checks.

Of course; for apples-to-apples comparison, all or none of the implementations should do bounds checks; with proper error reporting. For Go, to disable bounds checks there's a flag `-gcflags=all=-B`.

2. Second fix is to use `math/rand/v2.PCG` for random number generation. However, the proper fix would be to use the same algorithm consistently across all the languages. e.g. some simple LCG would suffice:

```
uint64_t seed = 123456789;

uint64_t rand()
{
  seed = (a * seed + c) % m;
  return seed;
}
```

Different random generators have different performance overhead and security properties, hence all implementations should use the same one. At the moment I used PCG, as it's in the standard library and well known.

3. Third fix is to avoid fetching env block all the time from the OS and instead load and parse it only once. Different languages have different overheads with regards to things touching OS, for various reasons.

There are two solutions for this. Do it once and reuse across `getPath()` calls; or pass it in as an argument. I opted to parse it during init time, rather than making it a flag, to stay compatible with other implementations.

---

Overall these changes resulted in ~8.4% performance improvement for ex9.